### PR TITLE
feat: add "shortcut icon dance" to disco mode

### DIFF
--- a/components/Program/Console/Commands/disco.tsx
+++ b/components/Program/Console/Commands/disco.tsx
@@ -17,6 +17,21 @@ export const discoCommand:Command = {
         return {exitStatus: 0, output: [{s: "Party time is over!"}]}
       } else {
         r.style.setProperty('--background', 'url("/misc/disco.gif")');
+        const interval = setInterval(() => {
+          const currentBackground = r.style.getPropertyValue('--background');
+          if (currentBackground !== 'url("/misc/disco.gif")') {
+            clearInterval(interval);
+            return;
+          }
+          _tm.shortCuts.forEach(shortcut => {
+            const randomX = Math.floor(Math.random() * _tm.screenSize.x);
+            const randomY = Math.floor(Math.random() * _tm.screenSize.y);
+            shortcut.position.x = randomX;
+            shortcut.position.y = randomY;
+          });
+          _tm.updateShortcuts(_tm.screenSize);
+          _tm.callUpdate('shortcuts');
+        }, 200);
         return {exitStatus: 0, output: [{s: "Party time!"}]}
       }
     }


### PR DESCRIPTION
Add a call to setInterval function, which randomizes the shortcut locations in the taskManager grid. Also implement the teardown with "clearInterval" when disco-mode is toggled off.

Related: #5